### PR TITLE
Able to outbid/match offers from embargo nations

### DIFF
--- a/static/scripts/ViewTrades.user.js
+++ b/static/scripts/ViewTrades.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Doc: View Trades
 // @namespace    https://politicsandwar.com/nation/id=19818
-// @version      6.94
+// @version      6.95
 // @description  Make Trading on the market Better!
 // @author       BlackAsLight
 // @include      https://politicsandwar.com/index.php?id=26*

--- a/static/scripts/ViewTrades.user.js
+++ b/static/scripts/ViewTrades.user.js
@@ -523,7 +523,7 @@ function CreateRow(tdTags) {
 		divTag.append(CreateElement('div', divTag => {
 			divTag.classList.add('Create')
 			divTag.style.setProperty('grid-area', 'Create')
-			if (offerType.startsWith('Receive')) {
+			if (offerType.startsWith('Receive') || offerType === 'Embargo') {
 				// Outbid + Match
 				divTag.append(CreateElement('a', aTag => {
 					aTag.classList.add(`${sellUnits ? 's' : 'b'}Outbid_${resource}`)


### PR DESCRIPTION
Previously, embargo trades only showed a 'Duplicate' button. Now they include 'Outbid' and 'Match' buttons like other receivable offers, allowing players to create competing offers against embargoed nations.